### PR TITLE
all: remove useless defines

### DIFF
--- a/auth-dialog/Makefile.am
+++ b/auth-dialog/Makefile.am
@@ -9,11 +9,7 @@ nm_ssh_auth_dialog_CPPFLAGS = \
 	-DICONDIR=\""$(datadir)/pixmaps"\" \
 	-DUIDIR=\""$(uidir)"\" \
 	-DBINDIR=\""$(bindir)"\" \
-	-DG_DISABLE_DEPRECATED \
-	-DGDK_DISABLE_DEPRECATED \
-	-DGNOME_DISABLE_DEPRECATED \
-	-DGNOMELOCALEDIR=\"$(datadir)/locale\" \
-	-DVERSION=\"$(VERSION)\"
+	-DGNOMELOCALEDIR=\"$(datadir)/locale\"
 
 nm_ssh_auth_dialog_SOURCES = \
 	main.c

--- a/properties/Makefile.am
+++ b/properties/Makefile.am
@@ -21,15 +21,10 @@ ui_DATA = nm-ssh-dialog.ui
 common_CFLAGS = \
         $(GTK_CFLAGS) \
         $(GNOMEKEYRING_CFLAGS) \
-        $(DISABLE_DEPRECATED) \
         -I$(top_srcdir)/ \
         -DICONDIR=\""$(datadir)/pixmaps"\" \
         -DUIDIR=\""$(uidir)"\" \
-        -DG_DISABLE_DEPRECATED \
-        -DGDK_DISABLE_DEPRECATED \
-        -DGNOME_DISABLE_DEPRECATED \
-        -DGNOMELOCALEDIR=\"$(datadir)/locale\" \
-        -DVERSION=\"$(VERSION)\"
+        -DGNOMELOCALEDIR=\"$(datadir)/locale\"
 
 libnm_vpn_plugin_ssh_la_CFLAGS = \
         $(common_CFLAGS) \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,11 +1,9 @@
 AM_CPPFLAGS = \
 	$(LIBNM_CFLAGS) \
 	$(GIO_CFLAGS) \
-	-DG_DISABLE_DEPRECATED \
 	-DBINDIR=\"$(bindir)\" \
 	-DPREFIX=\""$(prefix)"\" \
 	-DSYSCONFDIR=\""$(sysconfdir)"\" \
-	-DVERSION="\"$(VERSION)\"" \
 	-DLIBDIR=\""$(libdir)"\" \
 	-DLIBEXECDIR=\""$(libexecdir)"\" \
 	-DLOCALSTATEDIR=\""$(localstatedir)"\" \


### PR DESCRIPTION
VERSION is defined in config.h, we shouldn't define or redefine it.

There's no point in G_*_DEPRECATED by default other that it may break the build
in future.