### PR TITLE
SOCKS only SSH connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ stamp-h1
 properties/resources.c
 
 .dirstamp
-auth_dialog/nm-ssh-auth-dialog
+auth-dialog/nm-ssh-auth-dialog
 nm-ssh-service
 NetworkManager-ssh-*.tar*
 debian/autoreconf.before

--- a/Makefile.am
+++ b/Makefile.am
@@ -272,7 +272,7 @@ properties_libnm_ssh_properties_la_LDFLAGS = \
 
 ###################################################################################################
 
-libexec_PROGRAMS += auth_dialog/nm-ssh-auth-dialog
+libexec_PROGRAMS += auth-dialog/nm-ssh-auth-dialog
 
 auth_dialog_nm_ssh_auth_dialog_CPPFLAGS = \
 	$(GTK_CFLAGS) \

--- a/NetworkManager-ssh.spec
+++ b/NetworkManager-ssh.spec
@@ -78,7 +78,7 @@ rm -f %{buildroot}%{_libdir}/NetworkManager/lib*.la
 %{_libdir}/NetworkManager/lib*.so*
 %dir %{_datadir}/gnome-vpn-properties/ssh
 %{_datadir}/gnome-vpn-properties/ssh/nm-ssh-dialog.ui
-%{_datarootdir}/appdata/network-manager-ssh.metainfo.xml
+%{_datarootdir}/metainfo/network-manager-ssh.metainfo.xml
 
 %changelog
 

--- a/properties/advanced-dialog.c
+++ b/properties/advanced-dialog.c
@@ -55,6 +55,8 @@ static const char *advanced_keys[] = {
 	NM_SSH_KEY_REMOTE_DEV,
 	NM_SSH_KEY_TAP_DEV,
 	NM_SSH_KEY_REMOTE_USERNAME,
+	NM_SSH_KEY_SOCKS_ONLY_INTERFACE,
+	NM_SSH_KEY_SOCKS_BIND_ADDRESS,
 	NULL
 };
 
@@ -128,6 +130,26 @@ remote_username_toggled_cb (GtkWidget *check, gpointer user_data)
 		gtk_check_button_get_active (GTK_CHECK_BUTTON (check)));
 
 	widget = GTK_WIDGET (gtk_builder_get_object (builder, "remote_username_entry"));
+	gtk_widget_set_sensitive (widget, gtk_check_button_get_active (GTK_CHECK_BUTTON (check)));
+}
+
+static void
+socks_only_interface_toggled_cb (GtkWidget *check, gpointer user_data)
+{
+	GtkBuilder *builder = (GtkBuilder *) user_data;
+	GtkWidget *widget;
+
+	widget = GTK_WIDGET (gtk_builder_get_object (builder, "socks_only_interface_entry"));
+	gtk_widget_set_sensitive (widget, gtk_check_button_get_active (GTK_CHECK_BUTTON (check)));
+}
+
+static void
+socks_bind_address_toggled_cb (GtkWidget *check, gpointer user_data)
+{
+	GtkBuilder *builder = (GtkBuilder *) user_data;
+	GtkWidget *widget;
+
+	widget = GTK_WIDGET (gtk_builder_get_object (builder, "socks_bind_address_entry"));
 	gtk_widget_set_sensitive (widget, gtk_check_button_get_active (GTK_CHECK_BUTTON (check)));
 }
 
@@ -259,6 +281,44 @@ advanced_dialog_new (GHashTable *hash)
 		gtk_widget_set_sensitive (widget, FALSE);
 	}
 
+	widget = GTK_WIDGET (gtk_builder_get_object (builder, "socks_only_interface_checkbutton"));
+	g_assert (widget);
+	g_signal_connect (G_OBJECT (widget), "toggled", G_CALLBACK (socks_only_interface_toggled_cb), builder);
+
+	value = g_hash_table_lookup (hash, NM_SSH_KEY_SOCKS_ONLY_INTERFACE);
+	if (value && strlen (value)) {
+		gtk_check_button_set_active (GTK_CHECK_BUTTON (widget), TRUE);
+
+		widget = GTK_WIDGET (gtk_builder_get_object (builder, "socks_only_interface_entry"));
+		gtk_editable_set_text (GTK_EDITABLE (widget), value);
+		gtk_widget_set_sensitive (widget, TRUE);
+	} else {
+		gtk_check_button_set_active (GTK_CHECK_BUTTON (widget), FALSE);
+
+		widget = GTK_WIDGET (gtk_builder_get_object (builder, "socks_only_interface_entry"));
+		gtk_editable_set_text (GTK_EDITABLE (widget), NM_SSH_DEFAULT_SOCKS_ONLY_INTERFACE);
+		gtk_widget_set_sensitive (widget, FALSE);
+	}
+
+	widget = GTK_WIDGET (gtk_builder_get_object (builder, "socks_bind_address_checkbutton"));
+	g_assert (widget);
+	g_signal_connect (G_OBJECT (widget), "toggled", G_CALLBACK (socks_bind_address_toggled_cb), builder);
+
+	value = g_hash_table_lookup (hash, NM_SSH_KEY_SOCKS_BIND_ADDRESS);
+	if (value && strlen (value)) {
+		gtk_check_button_set_active (GTK_CHECK_BUTTON (widget), TRUE);
+
+		widget = GTK_WIDGET (gtk_builder_get_object (builder, "socks_bind_address_entry"));
+		gtk_editable_set_text (GTK_EDITABLE (widget), value);
+		gtk_widget_set_sensitive (widget, TRUE);
+	} else {
+		gtk_check_button_set_active (GTK_CHECK_BUTTON (widget), FALSE);
+
+		widget = GTK_WIDGET (gtk_builder_get_object (builder, "socks_bind_address_entry"));
+		gtk_editable_set_text (GTK_EDITABLE (widget), NM_SSH_DEFAULT_SOCKS_BIND_ADDRESS);
+		gtk_widget_set_sensitive (widget, FALSE);
+	}
+
 out:
 	return dialog;
 }
@@ -317,6 +377,24 @@ advanced_dialog_new_hash_from_dialog (GtkWidget *dialog, GError **error)
 		widget = GTK_WIDGET (gtk_builder_get_object (builder, "remote_username_entry"));
 		remote_username = gtk_editable_get_text (GTK_EDITABLE (widget));
 		g_hash_table_insert (hash, g_strdup (NM_SSH_KEY_REMOTE_USERNAME), g_strdup(remote_username));
+	}
+
+	widget = GTK_WIDGET (gtk_builder_get_object (builder, "socks_only_interface_checkbutton"));
+	if (gtk_check_button_get_active (GTK_CHECK_BUTTON (widget))) {
+		const gchar *socks_only_interface;
+
+		widget = GTK_WIDGET (gtk_builder_get_object (builder, "socks_only_interface_entry"));
+		socks_only_interface = gtk_editable_get_text (GTK_EDITABLE (widget));
+		g_hash_table_insert (hash, g_strdup (NM_SSH_KEY_SOCKS_ONLY_INTERFACE), g_strdup(socks_only_interface));
+	}
+
+	widget = GTK_WIDGET (gtk_builder_get_object (builder, "socks_bind_address_checkbutton"));
+	if (gtk_check_button_get_active (GTK_CHECK_BUTTON (widget))) {
+		const gchar *socks_bind_address;
+
+		widget = GTK_WIDGET (gtk_builder_get_object (builder, "socks_bind_address_entry"));
+		socks_bind_address = gtk_editable_get_text (GTK_EDITABLE (widget));
+		g_hash_table_insert (hash, g_strdup (NM_SSH_KEY_SOCKS_BIND_ADDRESS), g_strdup(socks_bind_address));
 	}
 
 	return hash;

--- a/properties/nm-ssh-dialog.ui
+++ b/properties/nm-ssh-dialog.ui
@@ -343,6 +343,78 @@ Please make sure the user you specify is allowed to open tun/tap devices on the 
                     <property name="position">5</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkHBox" id="socks_only_interface_hbox">
+                    <property name="visible">True</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkCheckButton" id="socks_only_interface_checkbutton">
+                        <property name="label" translatable="yes">Socks only (dummy interface):</property>
+                        <property name="visible">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="use_underline">True</property>
+                        <property name="draw_indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="socks_only_interface_entry">
+                        <property name="visible">True</property>
+                        <property name="text">dummy0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">5</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkHBox" id="socks_bind_address_hbox">
+                    <property name="visible">True</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkCheckButton" id="socks_bind_address_checkbutton">
+                        <property name="label" translatable="yes">Socks bind address:</property>
+                        <property name="visible">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="use_underline">True</property>
+                        <property name="draw_indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="socks_bind_address_entry">
+                        <property name="visible">True</property>
+                        <property name="text">localhost:8080</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">6</property>
+                  </packing>
+                </child>
               </object>
             </child>
             <child type="tab">

--- a/properties/nm-ssh-editor-plugin.c
+++ b/properties/nm-ssh-editor-plugin.c
@@ -170,6 +170,8 @@ import (NMVpnEditorPlugin *iface, const char *path, GError **error)
 		PARSE_IMPORT_KEY (REMOTE_KEY, NM_SSH_KEY_REMOTE, items, s_vpn)
 		PARSE_IMPORT_KEY_WITH_DEFAULT_VALUE_STR (AUTH_TYPE_KEY, NM_SSH_KEY_AUTH_TYPE, items, s_vpn, NM_SSH_AUTH_TYPE_SSH_AGENT)
 		PARSE_IMPORT_KEY_WITH_DEFAULT_VALUE_STR (REMOTE_USERNAME_KEY, NM_SSH_KEY_REMOTE_USERNAME, items, s_vpn, NM_SSH_DEFAULT_REMOTE_USERNAME);
+		PARSE_IMPORT_KEY(SOCKS_ONLY_INTERFACE, NM_SSH_KEY_SOCKS_ONLY_INTERFACE, items, s_vpn);
+		PARSE_IMPORT_KEY(SOCKS_BIND_ADDRESS, NM_SSH_KEY_SOCKS_BIND_ADDRESS, items, s_vpn);
 		PARSE_IMPORT_KEY (KEY_FILE_KEY, NM_SSH_KEY_KEY_FILE, items, s_vpn)
 		PARSE_IMPORT_KEY (REMOTE_IP_KEY, NM_SSH_KEY_REMOTE_IP, items, s_vpn)
 		PARSE_IMPORT_KEY (LOCAL_IP_KEY, NM_SSH_KEY_LOCAL_IP, items, s_vpn)
@@ -219,6 +221,8 @@ export (NMVpnEditorPlugin *iface,
 	const char *remote_dev = NULL;
 	const char *mtu = NULL;
 	const char *remote_username = NULL;
+	const char *socks_only_interface = NULL;
+	const char *socks_bind_address = NULL;
 	char *device_type = NULL;
 	char *tunnel_type = NULL;
 	char *ifconfig_cmd_local_6 = NULL;
@@ -312,6 +316,18 @@ export (NMVpnEditorPlugin *iface,
 	else
 		remote_username = g_strdup(NM_SSH_DEFAULT_REMOTE_USERNAME);
 
+	value = nm_setting_vpn_get_data_item (s_vpn, NM_SSH_KEY_SOCKS_ONLY_INTERFACE);
+	if (value && strlen (value))
+		socks_only_interface = value;
+	else
+		socks_only_interface = NULL;
+
+	value = nm_setting_vpn_get_data_item (s_vpn, NM_SSH_KEY_SOCKS_BIND_ADDRESS);
+	if (value && strlen (value))
+		socks_bind_address = value;
+	else
+		socks_bind_address = NULL;
+
 	value = nm_setting_vpn_get_data_item (s_vpn, NM_SSH_KEY_TAP_DEV);
 	if (value && IS_YES(value)) {
 		device_type = g_strdup("tap");
@@ -385,18 +401,38 @@ export (NMVpnEditorPlugin *iface,
 	fprintf (f, "%s=%s\n", DEV_TYPE_KEY, device_type);
 	fprintf (f, "%s=%s\n", TUNNEL_TYPE_KEY, tunnel_type);
 
+	if (socks_only_interface)
+		fprintf (f, "%s=%s\n", SOCKS_ONLY_INTERFACE, socks_only_interface);
+
+	if (socks_bind_address)
+		fprintf (f, "%s=%s\n", SOCKS_BIND_ADDRESS, socks_bind_address);
+
 	/* Add a little of bash script to probe for a free tun/tap device */
 	fprintf (f, "for i in `seq 0 255`; do ! %s $DEV_TYPE$i >& /dev/null && LOCAL_DEV=$i && break; done", IFCONFIG);
 
-	/* The generic lines that will perform the connection */
 	fprintf (f, "\n");
-	fprintf(f, "ssh -f %s -o PreferredAuthentications=%s -o NumberOfPasswordPrompts=%d -o Tunnel=$TUNNEL_TYPE -o ServerAliveInterval=10 -o TCPKeepAlive=yes -o TunnelDevice=$LOCAL_DEV:$REMOTE_DEV -o User=$REMOTE_USERNAME -o Port=$PORT -o HostName=$REMOTE $REMOTE \"%s $DEV_TYPE$REMOTE_DEV $REMOTE_IP netmask $NETMASK pointopoint $LOCAL_IP; %s\" && \\\n",
+	/* The generic lines that will perform the connection */
+	fprintf(f, "ssh -f %s -o PreferredAuthentications=%s -o NumberOfPasswordPrompts=%d -o ServerAliveInterval=10 -o TCPKeepAlive=yes -o User=$REMOTE_USERNAME -o Port=$PORT -o HostName=$REMOTE",
 		(key_file ? g_strconcat("-i ", key_file, NULL) : ""),
 		preferred_authentication,
-		password_prompt_nr,
-		IFCONFIG,
-		ifconfig_cmd_remote_6);
-	fprintf(f, "%s $DEV_TYPE$LOCAL_DEV $LOCAL_IP netmask $NETMASK pointopoint $REMOTE_IP; %s\n", IFCONFIG, ifconfig_cmd_local_6);
+		password_prompt_nr);
+
+	if (socks_bind_address)
+	{
+		fprintf(f, " -o DynamicForward=%s", socks_bind_address);
+	}
+
+	if (socks_only_interface)
+	{
+		fprintf(f, " -N $REMOTE");
+	}
+	else
+	{
+		fprintf(f, " -o Tunnel=$TUNNEL_TYPE -o TunnelDevice=$LOCAL_DEV:$REMOTE_DEV $REMOTE");
+		fprintf(f, " \"%s $DEV_TYPE$REMOTE_DEV $REMOTE_IP netmask $NETMASK pointopoint $LOCAL_IP; %s\" && \\\n", IFCONFIG, ifconfig_cmd_remote_6);
+		fprintf(f, "%s $DEV_TYPE$LOCAL_DEV $LOCAL_IP netmask $NETMASK pointopoint $REMOTE_IP; %s\n", IFCONFIG, ifconfig_cmd_local_6);
+	}
+	fprintf(f, "\\\n");
 
 	success = TRUE;
 

--- a/properties/nm-ssh-editor-plugin.h
+++ b/properties/nm-ssh-editor-plugin.h
@@ -71,6 +71,8 @@ typedef NMVpnEditor *(*NMVpnEditorFactory) (NMVpnEditorPlugin *editor_plugin,
 #define	PORT_KEY "PORT"
 #define	MTU_KEY "MTU"
 #define	REMOTE_DEV_KEY "REMOTE_DEV"
+#define	SOCKS_ONLY_INTERFACE "SOCKS_ONLY_INTERFACE"
+#define	SOCKS_BIND_ADDRESS "SOCKS_BIND_ADDRESS"
 #define	DEV_TYPE_KEY "DEV_TYPE"
 #define	NO_DEFAULT_ROUTE_KEY "NO_DEFAULT_ROUTE"
 #define	TUNNEL_TYPE_KEY "TUNNEL_TYPE"

--- a/shared/nm-service-defines.h
+++ b/shared/nm-service-defines.h
@@ -40,6 +40,8 @@
 #define	NM_SSH_KEY_SSH_AUTH_SOCK "ssh-auth-sock"
 #define	NM_SSH_KEY_TAP_DEV "tap-dev"
 #define	NM_SSH_KEY_REMOTE_USERNAME "remote-username"
+#define	NM_SSH_KEY_SOCKS_ONLY_INTERFACE "socks-only-interface"
+#define	NM_SSH_KEY_SOCKS_BIND_ADDRESS "socks-bind-address"
 #define	NM_SSH_KEY_IP_6 "ip-6"
 #define	NM_SSH_KEY_REMOTE_IP_6 "remote-ip-6"
 #define	NM_SSH_KEY_LOCAL_IP_6 "local-ip-6"
@@ -52,6 +54,8 @@
 #define	NM_SSH_DEFAULT_MTU 1500
 #define	NM_SSH_DEFAULT_REMOTE_DEV 100
 #define	NM_SSH_DEFAULT_REMOTE_USERNAME "root"
+#define	NM_SSH_DEFAULT_SOCKS_ONLY_INTERFACE "dummy0"
+#define	NM_SSH_DEFAULT_SOCKS_BIND_ADDRESS "localhost:8080"
 
 #define	NM_SSH_AUTH_TYPE_SSH_AGENT "ssh-agent"
 #define	NM_SSH_AUTH_TYPE_PASSWORD "password"


### PR DESCRIPTION
 * Allow SOCKS only connections (-D host:port, -D port)
 * Use dummy0 as interface
 * Fix bug in config validation, where only prefix of keys were
   compared

Fixes #41