### PR TITLE
build: disable libnm-glib support by default

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,10 @@ NetworkManager-ssh-1.2.8 (not released yet)
 Overview of changes since NetworkManager-ssh-1.2.6
 ==========================================================
 
+* libnm-glib compatibility (NetworkManager < 1.0) is disabled by default.
+  It can be enabled by passing --with-libnm-glib to configure script.
+  Nobody should need it by now. Users that still use this are encouraged
+  to let us know before the libnm-glib support is removed for good.
 * The auth helper in external UI mode can now be run without a display
   server. Future nmcli version will utilize this for handling the
   secrets without a graphical desktop.

--- a/configure.ac
+++ b/configure.ac
@@ -49,8 +49,8 @@ dnl GNOME support
 dnl
 AC_ARG_WITH(gnome, AS_HELP_STRING([--without-gnome], [Build NetworkManager-ssh without GNOME support, e.g. vpn service only]))
 AM_CONDITIONAL(WITH_GNOME, test x"$with_gnome" != xno)
-AC_ARG_WITH(libnm-glib, AS_HELP_STRING([--without-libnm-glib], [Build NetworkManager-ssh without libnm-glib comatibility]))
-AM_CONDITIONAL(WITH_LIBNM_GLIB, test x"$with_libnm_glib" != xno)
+AC_ARG_WITH(libnm-glib, AS_HELP_STRING([--with-libnm-glib], [Build NetworkManager-ssh without libnm-glib comatibility]))
+AM_CONDITIONAL(WITH_LIBNM_GLIB, test x"$with_libnm_glib" == xyes)
 AC_ARG_ENABLE(absolute-paths, AS_HELP_STRING([--enable-absolute-paths], [Use absolute paths to in .name files. Useful for development. (default is no)]))
 
 GETTEXT_PACKAGE=NetworkManager-ssh
@@ -71,7 +71,7 @@ if test x"$with_gnome" != xno; then
 	PKG_CHECK_MODULES(LIBNMA, libnma >= 1.1.0)
 	PKG_CHECK_MODULES(LIBSECRET, libsecret-1)
 
-	if test x"$with_libnm_glib" != xno; then
+	if test x"$with_libnm_glib" == xyes; then
 		PKG_CHECK_MODULES(LIBNM_GTK, libnm-gtk >= 1.1.0)
 		PKG_CHECK_MODULES(LIBNM_GLIB,
 			NetworkManager >= 1.1.0


### PR DESCRIPTION
By now nobody should be using this. Keep the code around for a little
longer just in case anybody still uses this.

The libnm-glib support also serves as an example how do we build two
different versions of the properties plugin. We'll soon be in a similar
situation with Gtk 4.0. (sigh.) Just don't drop it yet.