### PR TITLE
auth-dialog: don't connect to Gtk+ display until necessary

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,8 @@
+==========================================================
+NetworkManager-ssh-1.2.8 (not released yet)
+Overview of changes since NetworkManager-ssh-1.2.6
+==========================================================
+
+* The auth helper in external UI mode can now be run without a display
+  server. Future nmcli version will utilize this for handling the
+  secrets without a graphical desktop.

--- a/auth-dialog/main.c
+++ b/auth-dialog/main.c
@@ -182,6 +182,7 @@ get_secrets (const char *vpn_uuid,
 		return TRUE;
 	}
 
+	gtk_init (NULL, NULL);
 
 	dialog = NMA_VPN_PASSWORD_DIALOG (
 	            nma_vpn_password_dialog_new (_("Authenticate VPN"), prompt, NULL));
@@ -256,10 +257,9 @@ main (int argc, char *argv[])
 	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 	textdomain (GETTEXT_PACKAGE);
 
-	gtk_init (&argc, &argv);
-
 	context = g_option_context_new ("- ssh auth dialog");
 	g_option_context_add_main_entries (context, entries, GETTEXT_PACKAGE);
+	g_option_context_add_group (context, gtk_get_option_group (FALSE));
 	g_option_context_parse (context, &argc, &argv, NULL);
 	g_option_context_free (context);
 


### PR DESCRIPTION
In the external UI mode we may end up not needing a connection to the
display server at all.

This splits the parsing of Gtk+ command line arguments from connection
to the display. This also fixes the --help output to actually include
the Gtk+ arguments (such as --display).