### PR TITLE
fix bashism in nm_ssh_get_free_device

### DIFF
--- a/src/nm-ssh-service.c
+++ b/src/nm-ssh-service.c
@@ -592,7 +592,7 @@ nm_ssh_get_free_device (const char *device_type)
 
 	for (device = 0; device <= 255; device++)
 	{
-		system_cmd = (gpointer) g_strdup_printf ("%s %s%d >& /dev/null", IFCONFIG, device_type, device);
+		system_cmd = (gpointer) g_strdup_printf ("%s %s%d > /dev/null 2>&1", IFCONFIG, device_type, device);
 		if (system(system_cmd) != 0)
 		{
 			g_free(system_cmd);


### PR DESCRIPTION
On systems with default shell being anything other than bash the
redirection '>& /dev/null' may cause shell error, resulting in
nm_ssh_get_free_device always returning 0. When tun0 or tap0 is busy
this results in failure to establish the tunnel.

Replace bash-specific redirection form '>& /dev/null' with more generic
'> /dev/null 2>&1'.

Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>